### PR TITLE
fixed issue #20:improve/fix type hints. @retval-> @return

### DIFF
--- a/src/MathParser/AbstractMathParser.php
+++ b/src/MathParser/AbstractMathParser.php
@@ -33,7 +33,7 @@ abstract class AbstractMathParser
     
     /**
      * Return Letex
-     * @retval Lexer
+     * @return Lexer
      */
     public function getLexer()
     {
@@ -42,7 +42,7 @@ abstract class AbstractMathParser
     
     /**
      * Return Parser
-     * @retval Parser
+     * @return Parser
      */
     public function getParser()
     {
@@ -51,7 +51,7 @@ abstract class AbstractMathParser
     
     /**
      * Return the token list for the last parsed expression.
-     * @retval Token[]
+     * @return Token[]
      */
     public function getTokenList()
     {
@@ -60,7 +60,7 @@ abstract class AbstractMathParser
     
     /**
      * Return the AST of the last parsed expression.
-     * @retval Node
+     * @return Node
      */
     public function getTree()
     {

--- a/src/MathParser/ComplexMathParser.php
+++ b/src/MathParser/ComplexMathParser.php
@@ -30,7 +30,7 @@ class ComplexMathParser extends AbstractMathParser
      * Parse the given mathematical expression into an abstract syntax tree.
      *
      * @param string $text Input
-     * @retval Node
+     * @return Node
      */
     public function parse($text)
     {

--- a/src/MathParser/Exceptions/MathParserException.php
+++ b/src/MathParser/Exceptions/MathParserException.php
@@ -25,7 +25,7 @@ abstract class MathParserException extends \Exception
     /**
      * Get additional information about the exception.
      *
-     * @retval string
+     * @return string
      */
     public function getData()
     {

--- a/src/MathParser/Exceptions/ParenthesisMismatchException.php
+++ b/src/MathParser/Exceptions/ParenthesisMismatchException.php
@@ -26,7 +26,7 @@ class ParenthesisMismatchException extends MathParserException
     /**
      * Get the incorrect data that was encountered.
      *
-     * @retval string
+     * @return string
      */
     public function getData()
     {

--- a/src/MathParser/Exceptions/UnknownConstantException.php
+++ b/src/MathParser/Exceptions/UnknownConstantException.php
@@ -28,7 +28,7 @@ class UnknownConstantException extends MathParserException
     /**
      * Get the unkown constant that was encountered.
      *
-     * @retval string
+     * @return string
      */
     public function getConstant()
     {

--- a/src/MathParser/Exceptions/UnknownFunctionException.php
+++ b/src/MathParser/Exceptions/UnknownFunctionException.php
@@ -28,7 +28,7 @@ class UnknownFunctionException extends MathParserException
     /**
      * Get the unkown function that was encountered.
      *
-     * @retval string
+     * @return string
      */
     public function getFunction()
     {

--- a/src/MathParser/Exceptions/UnknownOperatorException.php
+++ b/src/MathParser/Exceptions/UnknownOperatorException.php
@@ -28,7 +28,7 @@ class UnknownOperatorException extends MathParserException
     /**
      * Get the unkown operator that was encountered.
      *
-     * @retval string
+     * @return string
      */
     public function getOperator()
     {

--- a/src/MathParser/Exceptions/UnknownTokenException.php
+++ b/src/MathParser/Exceptions/UnknownTokenException.php
@@ -26,7 +26,7 @@ class UnknownTokenException extends MathParserException
     /**
      * Get the unknown token that was encountered.
      *
-     * @retval string
+     * @return string
      */
     public function getName()
     {

--- a/src/MathParser/Extensions/Complex.php
+++ b/src/MathParser/Extensions/Complex.php
@@ -55,7 +55,7 @@ class Complex
     /**
      * Real part
      *
-     * @retval float real part
+     * @return float real part
      */
     public function r()
     {
@@ -65,7 +65,7 @@ class Complex
     /**
      * Imaginary part
      *
-     * @retval float imaginary part
+     * @return float imaginary part
      */
     public function i()
     {
@@ -78,7 +78,7 @@ class Complex
      * Return the modulus of the complex number z=x+iy, i.e.
      * sqrt(x^2 + y^2)
      *
-     * @retval float modulus
+     * @return float modulus
      */
     public function abs()
     {
@@ -91,7 +91,7 @@ class Complex
      * Returns the prinicpal argument of the complex number,
      * i.e. a number t with -pi < t <= pi, such that z = rexp(i*t) for
      * some positive real r
-     * @retval float argument
+     * @return float argument
      */
     public function arg()
     {
@@ -102,7 +102,7 @@ class Complex
     /**
      * test if the complex number is NAN
      *
-     * @retval bool
+     * @return bool
      */
     public function is_nan()
     {
@@ -113,7 +113,7 @@ class Complex
      * check whether a string represents a signed real number
      *
      * @param string $value
-     * @retval bool true if $value is a signed real number
+     * @return bool true if $value is a signed real number
      */
     private static function isSignedReal($value)
     {
@@ -127,7 +127,7 @@ class Complex
      *
      * @param string $value
      * @throws SyntaxErrorException if the string cannot be parsed
-     * @retval float
+     * @return float
      */
     private static function parseReal($value)
     {
@@ -144,7 +144,7 @@ class Complex
      *
      * @param mixed $value (Complex, Rational, int, float and strings accepted)
      * @throws SyntaxErrorException if the string cannot be parsed
-     * @retval Complex
+     * @return Complex
      */
     public static function parse($value)
     {
@@ -224,7 +224,7 @@ class Complex
      *
      * @param mixed $value (float, int, Rational)
      * @throws SyntaxErrorException if the string cannot be parsed
-     * @retval float
+     * @return float
      */
     private static function toFloat($x)
     {
@@ -244,7 +244,7 @@ class Complex
      * @param mixed $real (float, int, Rational)
      * @param mixed $imag (float, int, Rational)
      * @throws SyntaxErrorException if the string cannot be parsed
-     * @retval float
+     * @return float
      */
     public static function create($real, $imag)
     {
@@ -263,7 +263,7 @@ class Complex
      *
      * @param mixed $z (Complex, or parsable to Complex)
      * @param mixed $w (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function add($z, $w) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -280,7 +280,7 @@ class Complex
      *
      * @param mixed $z (Complex, or parsable to Complex)
      * @param mixed $w (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function sub($z, $w) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -297,7 +297,7 @@ class Complex
      *
      * @param mixed $z (Complex, or parsable to Complex)
      * @param mixed $w (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function mul($z, $w) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -314,7 +314,7 @@ class Complex
      *
      * @param mixed $z (Complex, or parsable to Complex)
      * @param mixed $w (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function div($z, $w) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -335,7 +335,7 @@ class Complex
      *
      * @param mixed $z (Complex, or parsable to Complex)
      * @param mixed $w (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function pow($z, $w) {
         // If exponent is an integer, compute the power using a square-and-multiply algorithm
@@ -353,7 +353,7 @@ class Complex
      *
      * @param mixed $z (Complex, or parsable to Complex)
      * @param int $n
-     * @retval Complex
+     * @return Complex
      */
     private static function powi($z, $n) {
         if ($n < 0) return static::div(1,static::powi($z, -$n));
@@ -383,7 +383,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function sin($z) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -398,7 +398,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function cos($z) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -413,7 +413,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function tan($z) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -429,7 +429,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function cot($z) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -445,7 +445,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function arcsin($z) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -463,7 +463,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function arccos($z) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -480,7 +480,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function arctan($z) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -499,7 +499,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function arccot($z)
     {
@@ -515,7 +515,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */    public static function exp($z) {
         if (!($z instanceof Complex)) $z = static::parse($z);
 
@@ -530,7 +530,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */    public static function log($z) {
         if (!($z instanceof Complex)) $z = static::parse($z);
 
@@ -549,7 +549,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
      public static function sinh($z) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -564,7 +564,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function cosh($z) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -579,7 +579,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function tanh($z) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -595,7 +595,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function arsinh($z) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -610,7 +610,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function arcosh($z) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -625,7 +625,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function artanh($z) {
         if (!($z instanceof Complex)) $z = static::parse($z);
@@ -640,7 +640,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval Complex
+     * @return Complex
      */
     public static function sqrt($z)
     {
@@ -657,7 +657,7 @@ class Complex
      *
      *
      * @param mixed $z (Complex, or parsable to Complex)
-     * @retval string
+     * @return string
      */
     public function __toString()
     {

--- a/src/MathParser/Extensions/Math.php
+++ b/src/MathParser/Extensions/Math.php
@@ -16,7 +16,7 @@ class Math {
      *
      * @param int $a
      * @param int $b
-     * @retval int
+     * @return int
      */
     public static function gcd($a, $b)
     {
@@ -42,7 +42,7 @@ class Math {
      *
      * @param float $a
      * @throws InvalidArgumentException if $a < 0
-     * @retval float
+     * @return float
      */
 	public static function logGamma($a) {
 		if($a < 0)
@@ -58,7 +58,7 @@ class Math {
      * Compute log(Gamma($x)) using Stirling asympotic expansion
      *
      * @param float $x
-     * @retval float
+     * @return float
      */
 	private static function logStirlingApproximation($x) {
 		$t = 0.5*log(2*pi()) - 0.5*log($x) + $x*(log($x))-$x;
@@ -78,7 +78,7 @@ class Math {
      * Compute factorial n! for an integer $n using iteration
      *
      * @param int $num
-     * @retval int
+     * @return int
      */
 	public static function Factorial($num) {
 		if ($num < 0) throw new \InvalidArgumentException("Fatorial calls should be >0.");
@@ -93,7 +93,7 @@ class Math {
      * Compute semi-factorial n!! for an integer $n using iteration
      *
      * @param int $num
-     * @retval int
+     * @return int
      */
 	public static function SemiFactorial($num) {
 		if ($num < 0) throw new \InvalidArgumentException("Semifactorial calls should be >0.");
@@ -110,7 +110,7 @@ class Math {
      * Compute log(Gamma($x)) using Lanczos approximation
      *
      * @param float $x
-     * @retval float
+     * @return float
      */
 	private static function lanczosApproximation($x) {
 		$g = 7;

--- a/src/MathParser/Extensions/Rational.php
+++ b/src/MathParser/Extensions/Rational.php
@@ -81,7 +81,7 @@ class Rational
      *
      * @param mixed $x (Rational, or parsable to Rational)
      * @param mixed $y (Rational, or parsable to Rational)
-     * @retval Rational
+     * @return Rational
      */
     public static function add($x, $y)
     {
@@ -102,7 +102,7 @@ class Rational
      *
      * @param mixed $x (Rational, or parsable to Rational)
      * @param mixed $y (Rational, or parsable to Rational)
-     * @retval Rational
+     * @return Rational
      */
     public static function sub($x, $y)
     {
@@ -123,7 +123,7 @@ class Rational
      *
      * @param mixed $x (Rational, or parsable to Rational)
      * @param mixed $y (Rational, or parsable to Rational)
-     * @retval Rational
+     * @return Rational
      */
     public static function mul($x, $y)
     {
@@ -144,7 +144,7 @@ class Rational
      *
      * @param mixed $x (Rational, or parsable to Rational)
      * @param mixed $y (Rational, or parsable to Rational)
-     * @retval Rational
+     * @return Rational
      */
     public static function div($x, $y)
     {
@@ -162,7 +162,7 @@ class Rational
     /**
      * convert rational number to string, adding a '+' if the number is positive
      *
-     * @retval string
+     * @return string
      */
     public function signed()
     {
@@ -177,7 +177,7 @@ class Rational
     /**
      * test whether a string represents an positive integer
      *
-     * @retval bool
+     * @return bool
      */
     private static function isInteger($value)
     {
@@ -187,7 +187,7 @@ class Rational
     /**
      * test whether a string represents a signed integer
      *
-     * @retval bool
+     * @return bool
      */
     private static function isSignedInteger($value)
     {
@@ -197,7 +197,7 @@ class Rational
     /**
      * test if the rational number is NAN
      *
-     * @retval bool
+     * @return bool
      */
     public function is_nan()
     {
@@ -210,7 +210,7 @@ class Rational
      *
      * @param $value mixed
      * @throws SyntaxErrorException
-     * @retval Rational
+     * @return Rational
      */
     public static function parse($value, $normalize=true)
     {
@@ -248,7 +248,7 @@ class Rational
      *
      * @param string|float $float
      * @param float $tolerance
-     * @retval Rational
+     * @return Rational
      */
     public static function fromFloat($float, $tolerance=1e-7)
     {
@@ -289,7 +289,7 @@ class Rational
     /**
      * Convert Rational to string
      *
-     * @retval string
+     * @return string
      */
     public function __toString()
     {

--- a/src/MathParser/Interpreting/ASCIIPrinter.php
+++ b/src/MathParser/Interpreting/ASCIIPrinter.php
@@ -63,7 +63,7 @@ class ASCIIPrinter implements Visitor
      * where `op` is one of `+`, `-`, `*`, `/` or `^`
      *
      *
-     * @retval string
+     * @return string
      * @param ExpressionNode $node AST to be typeset
      */
     public function visitExpressionNode(ExpressionNode $node)

--- a/src/MathParser/Interpreting/ComplexEvaluator.php
+++ b/src/MathParser/Interpreting/ComplexEvaluator.php
@@ -69,7 +69,7 @@ class ComplexEvaluator implements Visitor
     /**
      * Update the variables used for evaluating
      *
-     * @retval void
+     * @return void
      * @param array $variables Key/value pair holding current variable values
      */
     public function setVariables($variables)
@@ -87,7 +87,7 @@ class ComplexEvaluator implements Visitor
      * where `op` is one of `+`, `-`, `*`, `/` or `^`
      *
      *      `+`, `-`, `*`, `/` or `^`
-     * @retval float
+     * @return float
      * @param  ExpressionNode           $node AST to be evaluated
      * @throws UnknownOperatorException if the operator is something other than
      */
@@ -130,7 +130,7 @@ class ComplexEvaluator implements Visitor
      *
      * Retuns the value of an NumberNode
      *
-     * @retval float
+     * @return float
      * @param NumberNode $node AST to be evaluated
      */
     public function visitNumberNode(NumberNode $node)
@@ -155,7 +155,7 @@ class ComplexEvaluator implements Visitor
      * either by the constructor or set using the `Evaluator::setVariables()` method.
      *
      *      VariableNode is *not* set.
-     * @retval float
+     * @return float
      * @see Evaluator::setVariables() to define the variables
      *
      * @param  VariableNode             $node AST to be evaluated

--- a/src/MathParser/Interpreting/Differentiator.php
+++ b/src/MathParser/Interpreting/Differentiator.php
@@ -94,7 +94,7 @@ class Differentiator implements Visitor
      * - \\( (f^g)' = f^g  (g' \\log(f) + gf'/f) \\) with a simpler expression when g is a NumberNode
      *
      *      `+`, `-`, `*`, `/` or `^`
-     * @retval Node
+     * @return Node
      * @param  ExpressionNode           $node AST to be differentiated
      * @throws UnknownOperatorException if the operator is something other than
      */
@@ -171,7 +171,7 @@ class Differentiator implements Visitor
      * Create a NumberNode representing '0'. (The derivative of
      * a constant is indentically 0).
      *
-     * @retval Node
+     * @return Node
      * @param NumberNode $node AST to be differentiated
      */
     public function visitNumberNode(NumberNode $node)
@@ -195,7 +195,7 @@ class Differentiator implements Visitor
      * Create a NumberNode representing '0' or '1' depending on
      * the differetiation variable.
      *
-     * @retval Node
+     * @return Node
      * @param NumberNode $node AST to be differentiated
      */
     public function visitVariableNode(VariableNode $node)
@@ -237,7 +237,7 @@ class Differentiator implements Visitor
      *  \\( \\operatorname{arcoth}(f(x))' = f'(x) (1-f(x)^2) \\)
      *
      *          one of the above
-     * @retval Node
+     * @return Node
      * @param  FunctionNode             $node AST to be differentiated
      * @throws UnknownFunctionException if the function name doesn't match
      */
@@ -352,7 +352,7 @@ class Differentiator implements Visitor
      * Create a NumberNode representing '0'. (The derivative of
      * a constant is indentically 0).
      *
-     * @retval Node
+     * @return Node
      * @param ConstantNode $node AST to be differentiated
      */
     public function visitConstantNode(ConstantNode $node)

--- a/src/MathParser/Interpreting/Evaluator.php
+++ b/src/MathParser/Interpreting/Evaluator.php
@@ -69,7 +69,7 @@ class Evaluator implements Visitor
     /**
      * Update the variables used for evaluating
      *
-     * @retval void
+     * @return void
      * @param array $variables Key/value pair holding current variable values
      */
     public function setVariables($variables)
@@ -84,7 +84,7 @@ class Evaluator implements Visitor
      * where `op` is one of `+`, `-`, `*`, `/` or `^`
      *
      *      `+`, `-`, `*`, `/` or `^`
-     * @retval float
+     * @return float
      * @param  ExpressionNode           $node AST to be evaluated
      * @throws UnknownOperatorException if the operator is something other than
      */
@@ -134,7 +134,7 @@ class Evaluator implements Visitor
      *
      * Retuns the value of an NumberNode
      *
-     * @retval float
+     * @return float
      * @param NumberNode $node AST to be evaluated
      */
     public function visitNumberNode(NumberNode $node)
@@ -159,7 +159,7 @@ class Evaluator implements Visitor
      * either by the constructor or set using the `Evaluator::setVariables()` method.
      *
      *      VariableNode is *not* set.
-     * @retval float
+     * @return float
      * @see Evaluator::setVariables() to define the variables
      *
      * @param  VariableNode             $node AST to be evaluated
@@ -183,7 +183,7 @@ class Evaluator implements Visitor
      * an elementary function recognized by StdMathLexer and StdMathParser.
      *
      *      FunctionNode is *not* recognized.
-     * @retval float
+     * @return float
      * @see \MathParser\Lexer\StdMathLexer StdMathLexer
      * @see \MathParser\StdMathParser StdMathParser
      *
@@ -329,7 +329,7 @@ class Evaluator implements Visitor
      * Returns the value of a ConstantNode recognized by StdMathLexer and StdMathParser.
      *
      *      ConstantNode is *not* recognized.
-     * @retval float
+     * @return float
      * @see \MathParser\Lexer\StdMathLexer StdMathLexer
      * @see \MathParser\StdMathParser StdMathParser
      *

--- a/src/MathParser/Interpreting/LaTeXPrinter.php
+++ b/src/MathParser/Interpreting/LaTeXPrinter.php
@@ -80,7 +80,7 @@ class LaTeXPrinter implements Visitor
      * - Divisions are typeset using `\frac`
      * - Exponentiation adds braces around the power when needed.
      *
-     * @retval string
+     * @return string
      * @param ExpressionNode $node AST to be typeset
      */
     public function visitExpressionNode(ExpressionNode $node)
@@ -149,7 +149,7 @@ class LaTeXPrinter implements Visitor
      * Check if a multiplication needs an inserted \cdot or if
      * it can be safely written with implicit multiplication.
      *
-     * @retval bool
+     * @return bool
      * @param $left  AST of first factor
      * @param $right AST of second factor
      */
@@ -176,7 +176,7 @@ class LaTeXPrinter implements Visitor
      * Create a string giving LaTeX code for a NumberNode. Currently,
      * there is no special formatting of numbers.
      *
-     * @retval string
+     * @return string
      * @param NumberNode $node AST to be typeset
      */
     public function visitNumberNode(NumberNode $node)
@@ -215,7 +215,7 @@ class LaTeXPrinter implements Visitor
      * Create a string giving LaTeX code for a VariableNode. Currently,
      * there is no special formatting of variables.
      *
-     * @retval string
+     * @return string
      * @param VariableNode $node AST to be typeset
      */
     public function visitVariableNode(VariableNode $node)
@@ -226,7 +226,7 @@ class LaTeXPrinter implements Visitor
     /**
      * Generate LaTeX code for factorials
      *
-     * @retval string
+     * @return string
      * @param FunctionNode $node AST to be typeset
      */
     private function visitFactorialNode(FunctionNode $node)
@@ -260,7 +260,7 @@ class LaTeXPrinter implements Visitor
      * - `exp(op)` is either typeset as `e^{op}`, if `op` is a simple
      *      expression or as `\exp(op)` for more complicated operands.
      *
-     * @retval string
+     * @return string
      * @param FunctionNode $node AST to be typeset
      */
 
@@ -319,7 +319,7 @@ class LaTeXPrinter implements Visitor
      * Create a string giving LaTeX code for a ConstantNode.
      * `pi` typesets as `\pi` and `e` simply as `e`.
      *
-     * @retval string
+     * @return string
      * @param  ConstantNode             $node AST to be typeset
      * @throws UnknownConstantException for nodes representing other constants.
      */
@@ -347,7 +347,7 @@ class LaTeXPrinter implements Visitor
      *                          node. Operands with a lower precedence have parentheses
      *                          added.
      *                          be added at the beginning of the returned string.
-     * @retval string
+     * @return string
      * @param Node           $node     The AST to typeset
      * @param ExpressionNode $cutoff   A token representing the precedence of the parent
      * @param bool           $addSpace Flag determining whether an additional space should
@@ -394,7 +394,7 @@ class LaTeXPrinter implements Visitor
      * Nodes representing a single ConstantNode, VariableNode or NumberNodes (0--9)
      * are returned as-is. Other Nodes get curly braces around their LaTeX code.
      *
-     * @retval string
+     * @return string
      * @param Node $node AST to parse
      */
     public function bracesNeeded(Node $node)
@@ -411,7 +411,7 @@ class LaTeXPrinter implements Visitor
     /**
      * Check if Node is numeric, i.e. a NumberNode, IntegerNode or RationalNode
      *
-     * @retval bool
+     * @return bool
      * @param Node $node AST to check
      */
     private function isNumeric(Node $node)

--- a/src/MathParser/Interpreting/RationalEvaluator.php
+++ b/src/MathParser/Interpreting/RationalEvaluator.php
@@ -103,7 +103,7 @@ class RationalEvaluator implements Visitor
     /**
      * Update the variables used for evaluating
      *
-     * @retval void
+     * @return void
      * @param array $variables Key/value pair holding current variable values
      */
     public function setVariables($variables)
@@ -127,7 +127,7 @@ class RationalEvaluator implements Visitor
      * where `op` is one of `+`, `-`, `*`, `/` or `^`
      *
      *      `+`, `-`, `*`, `/` or `^`
-     * @retval float
+     * @return float
      * @param  ExpressionNode           $node AST to be evaluated
      * @throws UnknownOperatorException if the operator is something other than
      */
@@ -184,7 +184,7 @@ class RationalEvaluator implements Visitor
      *
      * Retuns the value of an NumberNode
      *
-     * @retval float
+     * @return float
      * @param NumberNode $node AST to be evaluated
      */
     public function visitNumberNode(NumberNode $node)
@@ -209,7 +209,7 @@ class RationalEvaluator implements Visitor
      * either by the constructor or set using the `Evaluator::setVariables()` method.
      *
      *      VariableNode is *not* set.
-     * @retval float
+     * @return float
      * @see Evaluator::setVariables() to define the variables
      *
      * @param  VariableNode             $node AST to be evaluated
@@ -233,7 +233,7 @@ class RationalEvaluator implements Visitor
      * an elementary function recognized by StdMathLexer and StdMathParser.
      *
      *      FunctionNode is *not* recognized.
-     * @retval float
+     * @return float
      * @see \MathParser\Lexer\StdMathLexer StdMathLexer
      * @see \MathParser\StdMathParser StdMathParser
      *
@@ -307,7 +307,7 @@ class RationalEvaluator implements Visitor
      * Returns the value of a ConstantNode recognized by StdMathLexer and StdMathParser.
      *
      *      ConstantNode is *not* recognized.
-     * @retval float
+     * @return float
      * @see \MathParser\Lexer\StdMathLexer StdMathLexer
      * @see \MathParser\StdMathParser StdMathParser
      *

--- a/src/MathParser/Lexing/Lexer.php
+++ b/src/MathParser/Lexing/Lexer.php
@@ -49,7 +49,7 @@ class Lexer
      * Adds the supplied TokenDefinition at the end of the list of known
      * tokens.
      *
-     * @retval void
+     * @return void
      * @param TokenDefinition $tokenDefinition token to add to the list of known tokens.
      */
     public function add(TokenDefinition $tokenDefinition)
@@ -66,7 +66,7 @@ class Lexer
      * care should be taken to add `sinh` before `sin`, otherwise the lexer will
      * never match a `sinh`.
      *
-     * @retval Token[] sequence of recognized tokens
+     * @return Token[] sequence of recognized tokens
      *      that doesn't match any knwon token.
      * @param  string                $input  String to tokenize.
      * @throws UnknownTokenException throwns when encountering characters in the input string
@@ -104,7 +104,7 @@ class Lexer
     /**
      * Find a matching token at the begining of the provided input.
      *
-     * @retval Token|null Matched token
+     * @return Token|null Matched token
      * @param string $input
      */
     private function findMatchingToken($input)

--- a/src/MathParser/Lexing/Token.php
+++ b/src/MathParser/Lexing/Token.php
@@ -63,7 +63,7 @@ class Token
      * @property length
      * Length of the input string matching the token.
      *
-     * @retval int length of string matching the token.
+     * @return int length of string matching the token.
      */
     public function length()
     {
@@ -75,7 +75,7 @@ class Token
      * Standarized value/name of the Token, usually the same as
      * what was matched in the the input string.
      *
-     * @retval string value of token
+     * @return string value of token
      */
     public function getValue()
     {
@@ -86,7 +86,7 @@ class Token
      * @property getType
      * Returns the type of the token, as defined in the TokenType class.
      *
-     * @retval int token type (as defined by TokenType)
+     * @return int token type (as defined by TokenType)
      */
     public function getType()
     {
@@ -96,7 +96,7 @@ class Token
     /**
      * Helper function, converting the Token to a printable string.
      *
-     * @retval string
+     * @return string
      */
     public function __toString()
     {
@@ -114,7 +114,7 @@ class Token
      * or an opening parenthesis. (Unless the first token is a a function name,
      * and the second is an opening parentheis.)
      *
-     * @retval boolean
+     * @return boolean
      */
     public static function canFactorsInImplicitMultiplication($token1, $token2)
     {

--- a/src/MathParser/Lexing/TokenDefinition.php
+++ b/src/MathParser/Lexing/TokenDefinition.php
@@ -55,7 +55,7 @@ class TokenDefinition
      * Try to match the given input to the current TokenDefinition.
      *
      * @param string $input Input string
-     * @retval Token|null Token matching the regular expression defining the TokenDefinition
+     * @return Token|null Token matching the regular expression defining the TokenDefinition
      */
     public function match($input)
     {
@@ -78,7 +78,7 @@ class TokenDefinition
      * Convert matching string to an actual Token.
      *
      * @param string $match Matching text.
-     * @retval Token Corresponding token.
+     * @return Token Corresponding token.
      */
     private function getTokenFromMatch($match)
     {

--- a/src/MathParser/Parsing/Nodes/ConstantNode.php
+++ b/src/MathParser/Parsing/Nodes/ConstantNode.php
@@ -42,7 +42,7 @@ class ConstantNode extends Node
     * @property getName
     *
     * Returns the name of the constant
-    * @retval string
+    * @return string
     */
     public function getName()
     {

--- a/src/MathParser/Parsing/Nodes/ExpressionNode.php
+++ b/src/MathParser/Parsing/Nodes/ExpressionNode.php
@@ -104,7 +104,7 @@ class ExpressionNode extends Node
     /**
      * Return the first (left) operand.
      *
-     * @retval Node|null
+     * @return  Node|null
      */
     public function getLeft()
     {
@@ -114,7 +114,7 @@ class ExpressionNode extends Node
     /**
      * Set the left operand.
      *
-     * @retval void
+     * @return void
      */
     public function setLeft($operand)
     {
@@ -124,7 +124,7 @@ class ExpressionNode extends Node
     /**
      * Return the operator.
      *
-     * @retval string
+     * @return string
      */
     public function getOperator()
     {
@@ -134,7 +134,7 @@ class ExpressionNode extends Node
     /**
      * Set the operator.
      *
-     * @retval void
+     * @return void
      */
     public function setOperator($operator)
     {
@@ -144,7 +144,7 @@ class ExpressionNode extends Node
     /**
      * Return the second (right) operand.
      *
-     * @retval Node|null
+     * @return Node|null
      */
     public function getRight()
     {
@@ -154,7 +154,7 @@ class ExpressionNode extends Node
     /**
      * Set the right operand.
      *
-     * @retval void
+     * @return void
      */
     public function setRight($operand)
     {
@@ -164,7 +164,7 @@ class ExpressionNode extends Node
     /**
      * Return the precedence of the ExpressionNode.
      *
-     * @retval int precedence
+     * @return int precedence
      */
     public function getPrecedence()
     {
@@ -183,7 +183,7 @@ class ExpressionNode extends Node
     * Returns true if the node can represent a unary operator, i.e. if
      * the operator is '+' or '-'-
      *
-     * @retval boolean
+     * @return boolean
      */
     public function canBeUnary()
     {
@@ -198,7 +198,7 @@ class ExpressionNode extends Node
      * (Left associative operators are lower precedence in this context.)
      *
      * @param Node $other Node to compare to.
-     * @retval boolean
+     * @return boolean
      */
     public function lowerPrecedenceThan($other)
     {

--- a/src/MathParser/Parsing/Nodes/Factories/MultiplicationNodeFactory.php
+++ b/src/MathParser/Parsing/Nodes/Factories/MultiplicationNodeFactory.php
@@ -46,7 +46,7 @@ class MultiplicationNodeFactory implements ExpressionNodeFactory
     *
     * @param Node|int $leftOperand First factor
     * @param Node|int $rightOperand Second factor
-    * @retval Node
+    * @return Node
     */
     public function makeNode($leftOperand, $rightOperand)
     {

--- a/src/MathParser/Parsing/Nodes/FunctionNode.php
+++ b/src/MathParser/Parsing/Nodes/FunctionNode.php
@@ -31,7 +31,7 @@ class FunctionNode extends Node
 
     /**
      * Return the name of the function
-     * @retval string
+     * @return string
      */
     public function getName()
     {
@@ -40,7 +40,7 @@ class FunctionNode extends Node
 
     /**
      * Return the operand
-     * @retval Node
+     * @return Node
      */
     public function getOperand()
     {
@@ -49,7 +49,7 @@ class FunctionNode extends Node
 
     /**
      * Set the operand
-     * @retval void
+     * @return void
      */
     public function setOperand($operand)
     {

--- a/src/MathParser/Parsing/Nodes/IntegerNode.php
+++ b/src/MathParser/Parsing/Nodes/IntegerNode.php
@@ -29,7 +29,7 @@ class IntegerNode extends Node
 
     /**
      * Returns the value
-     * @retval int|float
+     * @return int|float
      */
     public function getValue()
     {

--- a/src/MathParser/Parsing/Nodes/Node.php
+++ b/src/MathParser/Parsing/Nodes/Node.php
@@ -38,7 +38,7 @@ abstract class Node implements Visitable
      * token type is PosInt, Integer, RealNumber, Identifier or Constant
      * otherwise returns null.
      *
-     * @retval Node|null
+     * @return Node|null
      * @param Token $token Provided token
      */
     public static function rationalFactory(Token $token)
@@ -86,7 +86,7 @@ abstract class Node implements Visitable
      * token type is PosInt, Integer, RealNumber, Identifier or Constant
      * otherwise returns null.
      *
-     * @retval Node|null
+     * @return Node|null
      * @param Token $token Provided token
      */
     public static function factory(Token $token)
@@ -131,7 +131,7 @@ abstract class Node implements Visitable
      * Helper function, comparing two ASTs. Useful for testing
      * and also for some AST transformers.
      *
-     * @retval boolean
+     * @return boolean
      * @param Node|null $other Compare to this tree
      */
     abstract public function compareTo($other);
@@ -148,7 +148,7 @@ abstract class Node implements Visitable
      * $functionValue = $node->evaluate( array( 'x' => 1.3, 'y' => 1.4 ) );
      * ~~~
      *
-     * @retval floatval
+     * @return float
      * @param array $variables key-value array of variable values
      */
     public function evaluate($variables)
@@ -208,7 +208,7 @@ abstract class Node implements Visitable
      * Returns true if the node is a terminal node, i.e.
      * a NumerNode, VariableNode or ConstantNode.
      *
-     * @retval boolean
+     * @return boolean
      *
      */
     public function isTerminal()

--- a/src/MathParser/Parsing/Nodes/NumberNode.php
+++ b/src/MathParser/Parsing/Nodes/NumberNode.php
@@ -27,7 +27,7 @@ class NumberNode extends Node
 
     /**
      * Returns the value
-     * @retval int|float
+     * @return int|float
      */
     public function getValue()
     {

--- a/src/MathParser/Parsing/Nodes/RationalNode.php
+++ b/src/MathParser/Parsing/Nodes/RationalNode.php
@@ -49,7 +49,7 @@ class RationalNode extends Node
 
     /**
      * Returns the value
-     * @retval int|float
+     * @return int|float
      */
     public function getValue()
     {

--- a/src/MathParser/Parsing/Nodes/SubExpressionNode.php
+++ b/src/MathParser/Parsing/Nodes/SubExpressionNode.php
@@ -29,7 +29,7 @@ class SubExpressionNode extends Node
 
     /**
      * Returns the value
-     * @retval int|float
+     * @return int|float
      */
     public function getValue()
     {

--- a/src/MathParser/Parsing/Nodes/Traits/Sanitize.php
+++ b/src/MathParser/Parsing/Nodes/Traits/Sanitize.php
@@ -28,7 +28,7 @@ trait Sanitize {
     * Convert ints and floats to NumberNodes
     *
     * @param Node|int|float $operand
-    * @retval Node
+    * @return Node
     **/
     protected function sanitize($operand)
     {

--- a/src/MathParser/Parsing/Nodes/VariableNode.php
+++ b/src/MathParser/Parsing/Nodes/VariableNode.php
@@ -27,7 +27,7 @@ class VariableNode extends Node
 
     /**
      * Return the name of the variable
-     * @retval string
+     * @return string
      */
     public function getName()
     {

--- a/src/MathParser/Parsing/Stack.php
+++ b/src/MathParser/Parsing/Stack.php
@@ -27,7 +27,7 @@ class Stack {
 
     /**
      * Return the top element (without popping it)
-     * @retval mixed
+     * @return mixed
      */
     public function peek() {
         return end($this->data);
@@ -35,7 +35,7 @@ class Stack {
 
     /**
      * Return the top element and remove it from the stack.
-     * @retval mixed
+     * @return mixed
      */
     public function pop() {
         return array_pop($this->data);
@@ -43,7 +43,7 @@ class Stack {
 
     /**
      * Return the current number of elements in the stack.
-     * @retval int
+     * @return int
      */
     public function count() {
         return count($this->data);
@@ -52,7 +52,7 @@ class Stack {
     /**
      * Returns true if the stack is empty
      *
-     * @retval boolean
+     * @return boolean
      **/
     public function isEmpty()
     {

--- a/src/MathParser/RationalMathParser.php
+++ b/src/MathParser/RationalMathParser.php
@@ -48,7 +48,7 @@ class RationalMathParser extends AbstractMathParser
      * Parse the given mathematical expression into an abstract syntax tree.
      *
      * @param string $text Input
-     * @retval Node
+     * @return Node
      */
     public function parse($text)
     {

--- a/src/MathParser/StdMathParser.php
+++ b/src/MathParser/StdMathParser.php
@@ -47,7 +47,7 @@ class StdMathParser extends AbstractMathParser
      * Parse the given mathematical expression into an abstract syntax tree.
      *
      * @param string $text Input
-     * @retval Node
+     * @return Node
      */
     public function parse($text)
     {


### PR DESCRIPTION
all changes are replacing `@retval` with `@return`. AbstractMathParser has some automatic IDE changes, no changes to code apart from the `@return`